### PR TITLE
fix: use @apollo/server instead of apollo-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@apollo/server": "^4.7.0",
         "@graphql-codegen/cli": "^3.3.1",
         "@types/node": "^16.11.7",
-        "apollo-server": "^3.12.0",
         "axios": "^1.4.0",
         "knex": "^2.4.2",
         "pg": "^8.10.0",
@@ -275,17 +274,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@apollo/utils.dropunuseddefinitions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
-      "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
     "node_modules/@apollo/utils.fetcher": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz",
@@ -302,120 +290,12 @@
         "node": ">=14"
       }
     },
-    "node_modules/@apollo/utils.keyvaluecache": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.2.tgz",
-      "integrity": "sha512-p7PVdLPMnPzmXSQVEsy27cYEjVON+SH/Wb7COyW3rQN8+wJgT1nv9jZouYtztWW8ZgTkii5T6tC9qfoDREd4mg==",
-      "dependencies": {
-        "@apollo/utils.logger": "^1.0.0",
-        "lru-cache": "7.10.1 - 7.13.1"
-      }
-    },
-    "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@apollo/utils.logger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.1.tgz",
-      "integrity": "sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA=="
-    },
-    "node_modules/@apollo/utils.printwithreducedwhitespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
-      "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/utils.removealiases": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-1.0.0.tgz",
-      "integrity": "sha512-6cM8sEOJW2LaGjL/0vHV0GtRaSekrPQR4DiywaApQlL9EdROASZU5PsQibe2MWeZCOhNrPRuHh4wDMwPsWTn8A==",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/utils.sortast": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz",
-      "integrity": "sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/utils.stripsensitiveliterals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
-      "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/utils.usagereporting": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-1.0.1.tgz",
-      "integrity": "sha512-6dk+0hZlnDbahDBB2mP/PZ5ybrtCJdLMbeNJD+TJpKyZmSY6bA3SjI8Cr2EM9QA+AdziywuWg+SgbWUF3/zQqQ==",
-      "dependencies": {
-        "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.dropunuseddefinitions": "^1.1.0",
-        "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
-        "@apollo/utils.removealiases": "1.0.0",
-        "@apollo/utils.sortast": "^1.1.0",
-        "@apollo/utils.stripsensitiveliterals": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
     "node_modules/@apollo/utils.withrequired": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz",
       "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@apollographql/apollo-tools": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
-      "integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==",
-      "engines": {
-        "node": ">=8",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^14.2.1 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "dependencies": {
-        "xss": "^1.0.8"
       }
     },
     "node_modules/@ardatan/sync-fetch": {
@@ -1127,20 +1007,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/mock": {
-      "version": "8.7.20",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.7.20.tgz",
-      "integrity": "sha512-ljcHSJWjC/ZyzpXd5cfNhPI7YljRVvabKHPzKjEs5ElxWu2cdlLGvyNYepApXDsM/OJG/2xuhGM+9GWu5gEAPQ==",
-      "dependencies": {
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
-        "fast-json-stable-stringify": "^2.1.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/prisma-loader": {
       "version": "7.2.71",
       "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.71.tgz",
@@ -1463,14 +1329,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
-    "node_modules/@types/accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -1487,11 +1345,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.12",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
     "node_modules/@types/express": {
       "version": "4.17.14",
@@ -1741,264 +1594,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/apollo-datasource": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.2.tgz",
-      "integrity": "sha512-L5TiS8E2Hn/Yz7SSnWIVbZw0ZfEIXZCa5VUiVxD9P53JvSrf4aStvsFDlGWPvpIdCR+aly2CfoB79B9/JjKFqg==",
-      "deprecated": "The `apollo-datasource` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "apollo-server-env": "^4.2.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/apollo-reporting-protobuf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.4.0.tgz",
-      "integrity": "sha512-h0u3EbC/9RpihWOmcSsvTW2O6RXVaD/mPEjfrPkxRPTEPWqncsgOoRJw+wih4OqfH3PvTJvoEIf4LwKrUaqWog==",
-      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "@apollo/protobufjs": "1.2.6"
-      }
-    },
-    "node_modules/apollo-reporting-protobuf/node_modules/@apollo/protobufjs": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.6.tgz",
-      "integrity": "sha512-Wqo1oSHNUj/jxmsVp4iR3I480p6qdqHikn38lKrFhfzcDJ7lwd7Ck7cHRl4JE81tWNArl77xhnG/OkZhxKBYOw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "apollo-pbjs": "bin/pbjs",
-        "apollo-pbts": "bin/pbts"
-      }
-    },
-    "node_modules/apollo-reporting-protobuf/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-    },
-    "node_modules/apollo-server": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-3.12.0.tgz",
-      "integrity": "sha512-wZHLgBoIdGxr/YpPTG5RwNnS+B2y70T/nCegCnU6Yl+H3PXB92OIguLMhdJIZVjukIOhiQT12dNIehqLQ+1hMQ==",
-      "deprecated": "The `apollo-server` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "@types/express": "4.17.14",
-        "apollo-server-core": "^3.12.0",
-        "apollo-server-express": "^3.12.0",
-        "express": "^4.17.1"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-core": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.12.0.tgz",
-      "integrity": "sha512-hq7iH6Cgldgmnjs9FVSZeKWRpi0/ZR+iJ1arzeD2VXGxxgk1mAm/cz1Tx0TYgegZI+FvvrRl0UhKEx7sLnIxIg==",
-      "deprecated": "The `apollo-server-core` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0",
-        "@apollo/utils.usagereporting": "^1.0.0",
-        "@apollographql/apollo-tools": "^0.5.3",
-        "@apollographql/graphql-playground-html": "1.6.29",
-        "@graphql-tools/mock": "^8.1.2",
-        "@graphql-tools/schema": "^8.0.0",
-        "@josephg/resolvable": "^1.0.0",
-        "apollo-datasource": "^3.3.2",
-        "apollo-reporting-protobuf": "^3.4.0",
-        "apollo-server-env": "^4.2.1",
-        "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.7.2",
-        "apollo-server-types": "^3.8.0",
-        "async-retry": "^1.2.1",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graphql-tag": "^2.11.0",
-        "loglevel": "^1.6.8",
-        "lru-cache": "^6.0.0",
-        "node-abort-controller": "^3.0.1",
-        "sha.js": "^2.4.11",
-        "uuid": "^9.0.0",
-        "whatwg-mimetype": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@graphql-tools/merge": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
-      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
-      "dependencies": {
-        "@graphql-tools/utils": "8.9.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@graphql-tools/schema": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
-      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
-      "dependencies": {
-        "@graphql-tools/merge": "8.3.1",
-        "@graphql-tools/utils": "8.9.0",
-        "tslib": "^2.4.0",
-        "value-or-promise": "1.0.11"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@graphql-tools/utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/value-or-promise": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "node_modules/apollo-server-env": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.1.tgz",
-      "integrity": "sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==",
-      "deprecated": "The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/apollo-server-errors": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz",
-      "integrity": "sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==",
-      "deprecated": "The `apollo-server-errors` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-express": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-3.12.0.tgz",
-      "integrity": "sha512-m8FaGPUfDOEGSm7QRWRmUUGjG/vqvpQoorkId9/FXkC57fz/A59kEdrzkMt9538Xgsa5AV+X4MEWLJhTvlW3LQ==",
-      "deprecated": "The `apollo-server-express` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "@types/accepts": "^1.3.5",
-        "@types/body-parser": "1.19.2",
-        "@types/cors": "2.8.12",
-        "@types/express": "4.17.14",
-        "@types/express-serve-static-core": "4.17.31",
-        "accepts": "^1.3.5",
-        "apollo-server-core": "^3.12.0",
-        "apollo-server-types": "^3.8.0",
-        "body-parser": "^1.19.0",
-        "cors": "^2.8.5",
-        "parseurl": "^1.3.3"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "express": "^4.17.1",
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-express/node_modules/@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "node_modules/apollo-server-plugin-base": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.2.tgz",
-      "integrity": "sha512-wE8dwGDvBOGehSsPTRZ8P/33Jan6/PmL0y0aN/1Z5a5GcbFhDaaJCjK5cav6npbbGL2DPKK0r6MPXi3k3N45aw==",
-      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "apollo-server-types": "^3.8.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-types": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.8.0.tgz",
-      "integrity": "sha512-ZI/8rTE4ww8BHktsVpb91Sdq7Cb71rdSkXELSwdSR0eXu600/sY+1UXhTWdiJvk+Eq5ljqoHLwLbY2+Clq2b9A==",
-      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0",
-        "apollo-reporting-protobuf": "^3.4.0",
-        "apollo-server-env": "^4.2.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "node_modules/arg": {
@@ -2585,11 +2180,6 @@
         }
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
-    },
     "node_modules/dataloader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
@@ -2908,11 +2498,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
     "node_modules/fast-querystring": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.1.tgz",
@@ -3197,20 +2782,6 @@
       },
       "peerDependencies": {
         "graphql": "14 - 16"
-      }
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/graphql-ws": {
@@ -5188,26 +4759,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/xss/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@apollo/server": "^4.7.0",
     "@graphql-codegen/cli": "^3.3.1",
     "@types/node": "^16.11.7",
-    "apollo-server": "^3.12.0",
     "axios": "^1.4.0",
     "knex": "^2.4.2",
     "pg": "^8.10.0",

--- a/versions/v1/template/server.ts
+++ b/versions/v1/template/server.ts
@@ -4,7 +4,7 @@
 import {makeExecutableSchema, mergeSchemas} from '@graphql-tools/schema';
 import {schemaFromExecutor, wrapSchema} from '@graphql-tools/wrap';
 import {buildHTTPExecutor} from '@graphql-tools/executor-http'
-import {ApolloServer} from 'apollo-server';
+import {ApolloServer} from '@apollo/server';
 import {deepCloneVMFunction} from "./deep-clone-vm";
 import {CreateServerConfig, GraphQLServer, HelpersMap, ResolversMap} from "./types";
 import {createSatsumaKnex} from "./knex";

--- a/versions/v1/template/start-server.ts
+++ b/versions/v1/template/start-server.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import * as fs from "fs";
 import {createServer} from "./server";
 import {CreateServerConfig} from "./types";
-import {ApolloServer} from "apollo-server";
+import {ApolloServer} from "@apollo/server";
 
 const loadConfig = (): CreateServerConfig => {
     // Load the json file config.json


### PR DESCRIPTION
The `ApolloServer` from `apollo-server` only has `listen`. You get this error when you do `start()`:

```
Error: When using the `apollo-server` package, you don't need to call start(); just call listen().
```

I don't want to `listen` cause that's gonna list on a new port. This function is like a "batteries included" way of starting up the server, I guess.

Then I found an `ApolloServer`  on the `@apollo/server` module. It has `start()` method on it. 

Furthermore, it seems like `@apollo/server` is the [recommended way of installing](https://github.com/apollographql/apollo-server). `apollo-server` is [deprecated](https://www.npmjs.com/package/apollo-server).

The CLI which calls this fn will need to update to [initialize the server](https://github.com/apollographql/apollo-server#:~:text=apollo/server%20graphql-,Then%2C%20write%20the%20following%20to%20server.mjs.%20(By%20using%20the%20.mjs%20extension%2C%20Node%20lets%20you%20use%20the%20await%20keyword%20at%20the%20top%20level.),-import%20%7B%20ApolloServer) like:

```
import { startStandaloneServer } from '@apollo/server/standalone';
const { url } = await startStandaloneServer(server);
console.log(`🚀 Server ready at ${url}`);
```


FYI: I haven't tested this out yet. Only looked at code/documentation. I modified my local `node_modules` directory to have this change, but the change didn't seem to take affect.

Update: tested via using `npm link`. It's working on the querier.
